### PR TITLE
Encapsulate classes with factory. Make the class constructors non-pub…

### DIFF
--- a/src/main/java/com/hepexta/refactoring/encapsuation/descriptors/AttributeDescriptor.java
+++ b/src/main/java/com/hepexta/refactoring/encapsuation/descriptors/AttributeDescriptor.java
@@ -1,5 +1,7 @@
 package com.hepexta.refactoring.encapsuation.descriptors;
 
+import java.util.Date;
+
 public abstract class AttributeDescriptor {
 
     private String name;
@@ -13,5 +15,29 @@ public abstract class AttributeDescriptor {
     }
 
     protected AttributeDescriptor() {
+    }
+
+    public static AttributeDescriptor forInteger(String name, Class parent) {
+        return new DefaultDescriptor(name, parent, Integer.TYPE);
+    }
+
+    public static AttributeDescriptor forDate(String name, Class parent) {
+        return new DefaultDescriptor(name, parent, Date.class);
+    }
+
+    public static AttributeDescriptor forBoolean(String name, Class parent) {
+        return new DefaultDescriptor(name, parent, Boolean.TYPE);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Class getParentType() {
+        return parentType;
+    }
+
+    public Class getType() {
+        return type;
     }
 }

--- a/src/main/java/com/hepexta/refactoring/encapsuation/descriptors/BooleanDescriptor.java
+++ b/src/main/java/com/hepexta/refactoring/encapsuation/descriptors/BooleanDescriptor.java
@@ -2,11 +2,7 @@ package com.hepexta.refactoring.encapsuation.descriptors;
 
 public class BooleanDescriptor extends AttributeDescriptor {
 
-    public BooleanDescriptor() {
+    protected BooleanDescriptor() {
         super();
-    }
-
-    public BooleanDescriptor(String name, Class parent) {
-        super(name, parent, Boolean.TYPE);
     }
 }

--- a/src/main/java/com/hepexta/refactoring/encapsuation/descriptors/DefaultDescriptor.java
+++ b/src/main/java/com/hepexta/refactoring/encapsuation/descriptors/DefaultDescriptor.java
@@ -2,11 +2,7 @@ package com.hepexta.refactoring.encapsuation.descriptors;
 
 public class DefaultDescriptor extends AttributeDescriptor {
 
-    public DefaultDescriptor() {
-        super();
-    }
-
-    public DefaultDescriptor(String name, Class parent, Class type) {
+    protected DefaultDescriptor(String name, Class parent, Class type) {
         super(name, parent, type);
     }
 }

--- a/src/main/java/com/hepexta/refactoring/encapsuation/descriptors/ReferenceDescriptor.java
+++ b/src/main/java/com/hepexta/refactoring/encapsuation/descriptors/ReferenceDescriptor.java
@@ -12,4 +12,8 @@ public class ReferenceDescriptor extends AttributeDescriptor {
         super(name, parent, objectClass);
         this.stringClass = stringClass;
     }
+
+    public static ReferenceDescriptor forObject(String name, Class parent, Class<String> stringClass) {
+        return new ReferenceDescriptor(name, parent, Object.class, stringClass);
+    }
 }

--- a/src/test/java/com/hepexta/refactoring/encapsuation/descriptors/AttributeDescriptorTest.java
+++ b/src/test/java/com/hepexta/refactoring/encapsuation/descriptors/AttributeDescriptorTest.java
@@ -15,14 +15,42 @@ public class AttributeDescriptorTest {
         Assert.assertEquals(6, descriptors.size());
     }
 
+    @Test
+    public void test_DefaultDescriptor_integer() {
+        String name = "remoteId";
+        AttributeDescriptor integerDescriptor = DefaultDescriptor.forInteger(name, getClass());
+        Assert.assertEquals(name, integerDescriptor.getName());
+        Assert.assertEquals(Integer.TYPE, integerDescriptor.getType());
+        Assert.assertEquals(getClass(), integerDescriptor.getParentType());
+    }
+
+    @Test
+    public void test_DefaultDescriptor_date() {
+        String name = "createdDate";
+        AttributeDescriptor integerDescriptor = DefaultDescriptor.forDate(name, getClass());
+        Assert.assertEquals(name, integerDescriptor.getName());
+        Assert.assertEquals(Date.class, integerDescriptor.getType());
+        Assert.assertEquals(getClass(), integerDescriptor.getParentType());
+    }
+
+    @Test
+    public void test_ReferenceDescriptor() {
+        String name = "createdBy";
+        AttributeDescriptor integerDescriptor = ReferenceDescriptor.forObject(name, getClass(), String.class);
+        Assert.assertEquals(name, integerDescriptor.getName());
+        Assert.assertEquals(Object.class, integerDescriptor.getType());
+        Assert.assertEquals(getClass(), integerDescriptor.getParentType());
+    }
+
     private List<AttributeDescriptor> createAttributeDescriptors() {
         List<AttributeDescriptor> result = new ArrayList<>();
-        result.add(new DefaultDescriptor("remoteId", getClass(), Integer.TYPE));
-        result.add(new DefaultDescriptor("createdDate", getClass(), Date.class));
-        result.add(new DefaultDescriptor("lastChangedDate", getClass(), Date.class));
-        result.add(new ReferenceDescriptor("createdBy", getClass(), Object.class, String.class));
-        result.add(new DefaultDescriptor("optimisticLockVersion", getClass(), Integer.TYPE));
-        result.add(new BooleanDescriptor("isColor", getClass()));
+        result.add(AttributeDescriptor.forInteger("remoteId", getClass()));
+        result.add(AttributeDescriptor.forDate("createdDate", getClass()));
+        result.add(AttributeDescriptor.forDate("lastChangedDate", getClass()));
+        result.add(ReferenceDescriptor.forObject("createdBy", getClass(), String.class));
+        result.add(AttributeDescriptor.forInteger("optimisticLockVersion", getClass()));
+        result.add(AttributeDescriptor.forBoolean("isColor", getClass()));
         return result;
     }
+
 }


### PR DESCRIPTION
…lic and let clients create instances of them using a Factory.

Benefits and Liabilities

+  Simplifies the creation of kinds of instances by making the set available through intention-revealing methods.

+  Reduces the “conceptual weight” [Bloch] of a package by hiding classes that don’t need to be public.

+  Helps enforce the mantra “program to an interface, not an implementation” [DP].

–  Requires new/updated Creation Methods when new kinds of instances must be created.

–  Limits customization when clients can only access a Factory’s binary code, not its source code.